### PR TITLE
Admin management display page

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,3 +152,6 @@ heroku run rails db:seed
 * Sai Nithin
 * Vinayaka Hegde
 * [Legacy Code](https://github.com/tamu-edu-students/csce606-ELRC-Synergistic-Leadership-Theory)
+
+
+# demo check commit

--- a/README.md
+++ b/README.md
@@ -154,5 +154,3 @@ heroku run rails db:seed
 * [Legacy Code](https://github.com/tamu-edu-students/csce606-ELRC-Synergistic-Leadership-Theory)
 
 
-# demo check commit
-# second demo push

--- a/README.md
+++ b/README.md
@@ -155,3 +155,4 @@ heroku run rails db:seed
 
 
 # demo check commit
+# second demo push

--- a/rails_root/app/controllers/admins_controller.rb
+++ b/rails_root/app/controllers/admins_controller.rb
@@ -1,4 +1,6 @@
-#admins_controller.rb
+# frozen_string_literal: true
+
+# admins_controller.rb
 class AdminsController < ApplicationController
   def index
     @survey_responses = SurveyResponse.get_all_responses(page: params[:page], per_page: 20)

--- a/rails_root/app/controllers/survey_responses_controller.rb
+++ b/rails_root/app/controllers/survey_responses_controller.rb
@@ -25,6 +25,7 @@ class SurveyResponsesController < ApplicationController
   def show
     return return_to_root 'You are not logged in.' if current_user_id.nil?
     return return_to_root 'You cannot view this result.' if current_user_id != @survey_response.profile.user_id
+    
 
     flash.keep(:warning)
   end

--- a/rails_root/app/controllers/survey_responses_controller.rb
+++ b/rails_root/app/controllers/survey_responses_controller.rb
@@ -25,7 +25,6 @@ class SurveyResponsesController < ApplicationController
   def show
     return return_to_root 'You are not logged in.' if current_user_id.nil?
     return return_to_root 'You cannot view this result.' if current_user_id != @survey_response.profile.user_id
-    
 
     flash.keep(:warning)
   end

--- a/rails_root/app/helpers/admins_helper.rb
+++ b/rails_root/app/helpers/admins_helper.rb
@@ -1,2 +1,5 @@
+# frozen_string_literal: true
+
+# helper method for the admin controller
 module AdminsHelper
 end

--- a/rails_root/app/models/survey_response.rb
+++ b/rails_root/app/models/survey_response.rb
@@ -16,10 +16,10 @@ class SurveyResponse < ApplicationRecord
   belongs_to :profile,
              class_name: 'SurveyProfile'
 
-  has_many :invitations, 
-            foreign_key: :parent_response_id, 
-            class_name: 'Invitation',
-            dependent: :destroy
+  has_many :invitations,
+           foreign_key: :parent_response_id,
+           class_name: 'Invitation',
+           dependent: :destroy
 
   def self.create_from_params(user_id, params)
     # FIXME: When we look up things and fail, we should use more descriptive exceptions instead of ActiveRecord::RecordNotFound

--- a/rails_root/app/views/admins/index.html.erb
+++ b/rails_root/app/views/admins/index.html.erb
@@ -8,22 +8,26 @@
     <div class="table-responsive">
       <table class = "table">
         <thead>
-            <tr>
-                <th>ID</th>
-                <th>Profile</th>
-                <th>Share Code</th>
-                <th>Created At</th>
-            </tr>
+          <tr>
+            <th>ID</th>
+            <th>Profile</th>
+            <th>Share Code</th>
+            <th>Created At</th>
+            <th>View Survey</th> 
+          </tr>
         </thead>
         <% if @survey_responses.present? %>
           <tbody>
             <% @survey_responses.each do |response| %>
-                <tr>
-                    <td><%= response.id %></td>
-                    <td><%= response.profile.user_id %></td>
-                    <td><%= response.share_code %></td>
-                    <td><%= response.created_at.strftime('%Y-%m-%d %H:%M:%S') %></td>
-                </tr>
+              <tr>
+                <td><%= response.id %></td>
+                <td><%= response.profile.user_id %></td>
+                <td><%= response.share_code %></td>
+                <td><%= response.created_at.strftime('%Y-%m-%d %H:%M:%S') %></td>
+                <td>
+                <%= link_to 'View Survey', survey_response_path(response) %>
+                </td>
+              </tr>
             <% end %>
           </tbody>
         <% end %>

--- a/rails_root/app/views/layouts/_header.html.erb
+++ b/rails_root/app/views/layouts/_header.html.erb
@@ -24,6 +24,10 @@
         <%= link_to "About", about_path, class: "nav-link #{'active' if current_page?(about_path)}" %>
       </li>
       <li class="nav-item">
+        <%= link_to "Admin Dashboard", admin_dashboard_path, class: "nav-link" %> <!-- Admin Dashboard Link -->
+      </li>
+      
+      <li class="nav-item">
         <%# <%= link_to "Survey Responses", survey_responses_path, class: "nav-link #{'active' if current_page?(survey_responses_path)}" %>
       </li>
       <li class="nav-item">

--- a/rails_root/config/routes.rb
+++ b/rails_root/config/routes.rb
@@ -8,7 +8,9 @@ Rails.application.routes.draw do
 
   get 'home/index'
   get 'about', to: 'about#index'
-  get '/admin', to: 'admins#index'
+  get '/admin', to: 'admins#index', as: 'admin_dashboard'
+  #get 'survey_responses/:id', to: 'survey_responses#show', as: 'survey_response'
+
 
   # get 'survey', to: 'survey_responses#new', as: 'survey'
   # get 'survey/page/:page', to: 'survey_responses#survey', as: 'survey_page'

--- a/rails_root/features/admin_management.feature
+++ b/rails_root/features/admin_management.feature
@@ -1,0 +1,12 @@
+Feature: Admin Dashboard Access
+  I want to see the Admin Dashboard link
+  So that I can access administrative functions
+
+  Background:
+    Given I am on the homepage
+    And I try to login
+
+  Scenario: Principal sees "Admin Dashboard" link and clicks it
+    Then I should see "Admin Dashboard" in the header
+    When I click on "Admin Dashboard"
+    Then I should be on the Admin Dashboard page

--- a/rails_root/features/step_definitions/admin_management_steps.rb
+++ b/rails_root/features/step_definitions/admin_management_steps.rb
@@ -1,0 +1,27 @@
+# Step definition for navigating to the homepage
+Given('I am on the homepage') do
+  visit root_path
+  expect(page).to have_current_path(root_path)  # Ensure the user is on the homepage
+end
+
+Given('I have logged in as a {string}') do |role|
+  # Create a user with the specified role (principal, teacher, superintendent)
+  @user = FactoryBot.create(:survey_profile, role: role)
+  allow_any_instance_of(ApplicationController).to receive(:current_user_id).and_return(@user.user_id)
+end
+
+Then('I should see {string} in the header') do |link_text|
+  # Check that the Admin Dashboard link is present
+  expect(page).to have_link(link_text)
+end
+
+When('I click on {string}') do |link_text|
+  # Click the Admin Dashboard link
+  click_link(link_text)
+end
+
+Then('I should be on the Admin Dashboard page') do
+  # Verify that the user is redirected to the Admin Dashboard page
+  expect(current_path).to eq(admin_dashboard_path)
+  expect(page).to have_content('Admin Dashboard')
+end

--- a/rails_root/features/step_definitions/admin_management_steps.rb
+++ b/rails_root/features/step_definitions/admin_management_steps.rb
@@ -1,12 +1,14 @@
+# frozen_string_literal: true
+
 # Step definition for navigating to the homepage
 Given('I am on the homepage') do
   visit root_path
-  expect(page).to have_current_path(root_path)  # Ensure the user is on the homepage
+  expect(page).to have_current_path(root_path) # Ensure the user is on the homepage
 end
 
 Given('I have logged in as a {string}') do |role|
   # Create a user with the specified role (principal, teacher, superintendent)
-  @user = FactoryBot.create(:survey_profile, role: role)
+  @user = FactoryBot.create(:survey_profile, role:)
   allow_any_instance_of(ApplicationController).to receive(:current_user_id).and_return(@user.user_id)
 end
 

--- a/rails_root/spec/helpers/admins_helper_spec.rb
+++ b/rails_root/spec/helpers/admins_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 # Specs in this file have access to a helper object that includes

--- a/rails_root/spec/requests/admin_dashboard_spec.rb
+++ b/rails_root/spec/requests/admin_dashboard_spec.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
-RSpec.describe "Admin Dashboard Access", type: :request do
+RSpec.describe 'Admin Dashboard Access', type: :request do
   # Create a user with the principal role (you can change this to other roles if needed)
   let(:user) { FactoryBot.create(:survey_profile, role: 'Teacher') }
 
@@ -8,8 +10,8 @@ RSpec.describe "Admin Dashboard Access", type: :request do
     allow_any_instance_of(SurveyResponsesController).to receive(:current_user_id).and_return(user.user_id)
   end
 
-  describe "GET / (Homepage)" do
-    it "displays the Admin Dashboard link in the header" do
+  describe 'GET / (Homepage)' do
+    it 'displays the Admin Dashboard link in the header' do
       # Visit the homepage
       get root_path
 
@@ -18,8 +20,8 @@ RSpec.describe "Admin Dashboard Access", type: :request do
     end
   end
 
-  describe "GET /admin_dashboard" do
-    it "redirects to the Admin Dashboard page when clicked" do
+  describe 'GET /admin_dashboard' do
+    it 'redirects to the Admin Dashboard page when clicked' do
       # Visit the Admin Dashboard page
       get admin_dashboard_path
 

--- a/rails_root/spec/requests/admin_dashboard_spec.rb
+++ b/rails_root/spec/requests/admin_dashboard_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe "Admin Dashboard Access", type: :request do
+  # Create a user with the principal role (you can change this to other roles if needed)
+  let(:user) { FactoryBot.create(:survey_profile, role: 'Teacher') }
+
+  before do
+    allow_any_instance_of(SurveyResponsesController).to receive(:current_user_id).and_return(user.user_id)
+  end
+
+  describe "GET / (Homepage)" do
+    it "displays the Admin Dashboard link in the header" do
+      # Visit the homepage
+      get root_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('Admin Dashboard')
+    end
+  end
+
+  describe "GET /admin_dashboard" do
+    it "redirects to the Admin Dashboard page when clicked" do
+      # Visit the Admin Dashboard page
+      get admin_dashboard_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('Admin Dashboard')
+    end
+  end
+end

--- a/rails_root/spec/requests/admins_spec.rb
+++ b/rails_root/spec/requests/admins_spec.rb
@@ -1,11 +1,12 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
-RSpec.describe "Admins", type: :request do
-  describe "GET /index" do
-    it "returns http success" do
-      get "/admins/index"
+RSpec.describe 'Admins', type: :request do
+  describe 'GET /index' do
+    it 'returns http success' do
+      get '/admins/index'
       expect(response).to have_http_status(:success)
     end
   end
-
 end

--- a/rails_root/spec/views/admins/index.html.erb_spec.rb
+++ b/rails_root/spec/views/admins/index.html.erb_spec.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
-RSpec.describe "admins/index.html.erb", type: :view do
+RSpec.describe 'admins/index.html.erb', type: :view do
   pending "add some examples to (or delete) #{__FILE__}"
 end


### PR DESCRIPTION
Added A feature to display Admin Dashboard button to landing page header. 
The Admin Dashboard button redirects to the admin dashboard page which contains all the surveys. 
The admin dashboard also contains the link to individual survey link that displays the survey response. 
Added cucumber scenario and Rspec tests to test these features.